### PR TITLE
Fix xbuild-cmake build command error

### DIFF
--- a/xbuild.bashrc
+++ b/xbuild.bashrc
@@ -350,9 +350,9 @@ xbuild-cmake()
         fi
         # exec cmake build
         if [ "$MP_VERBOSE" == "debug" ]; then
-            echo "cmake --build $CMAKE_OUTDIR --config $MP_CONFIG $CMAKE_DEFS | tee $LOGFILE"
+            echo "cmake --build $CMAKE_OUTDIR --config $MP_CONFIG | tee $LOGFILE"
         fi
-        cmake --build $CMAKE_OUTDIR --config $MP_CONFIG -Wno-dev $CMAKE_DEFS | tee $LOGFILE
+        cmake --build $CMAKE_OUTDIR --config $MP_CONFIG | tee $LOGFILE
     else
         xbuild-print "ERROR: Unknown verb ($MP_VERB)" red b
         return


### PR DESCRIPTION
There are two problems in xbuild-cmake build command:
1. `-Wno-dev` is not for cmake --build
2. Extra `$CMAKE_DEFS` is for config, but not for build

The fix is to remove above unnecessary parameters