### PR TITLE
Support command git xbuild create

### DIFF
--- a/bin/git-xbuild
+++ b/bin/git-xbuild
@@ -21,6 +21,7 @@ xbuildhelp()
         echo "    git xbuild create <-t|--target TARGETNAME> <--target-type TYPE> [--kernel]"
         echo "      --target: the target name"
         echo "      --kernel: the target is in kernel mode"
+        echo "      --project: initialize project in current folder"
         echo "      --target-type: the target type, supports following values"
         echo "        * console: target is a consle app"
         echo "        * app: target is a GUI app"
@@ -71,7 +72,7 @@ fi
 # [Valid XBuild Parameters]
 # xbuild target name
 ARG_TARGET=
-# xbuild target type, includes following values: project, console, app, slib, dlib, test
+# xbuild target type, includes following values: console, app, slib, dlib, test
 ARG_TARGET_TYPE=
 # xbuild target platform, includes following values: Android, iOS, watchOS, tvOS, visionOS
 ARG_TARGET_PLATFORM=

--- a/bin/git-xbuild
+++ b/bin/git-xbuild
@@ -71,7 +71,7 @@ fi
 # [Valid XBuild Parameters]
 # xbuild target name
 ARG_TARGET=
-# xbuild target type, includes following values: console, app, slib, dlib, test
+# xbuild target type, includes following values: project, console, app, slib, dlib, test
 ARG_TARGET_TYPE=
 # xbuild target platform, includes following values: Android, iOS, watchOS, tvOS, visionOS
 ARG_TARGET_PLATFORM=
@@ -144,6 +144,10 @@ while [[ $# -gt 0 ]]; do
       ARG_TARGET_PLATFORM=ios
       shift # past argument
       ;;
+    --project)
+      ARG_TARGET_TYPE=project
+      shift # past argument
+      ;;
     --target-type)
       [[ "$ARG_TARGET_TYPE" == "" ]] || echo "Error: compiler $ARG_TARGET_TYPE and $2 cannot be set at the same time"
       [[ "$2" == "" ]] && echo "Error: missing target type value"
@@ -213,6 +217,32 @@ done
 
 if [ "$XBUILD_COMMAND" == "create" ]; then
     echo " "
+    if [ "$ARG_TARGET_TYPE" == "project" ]; then
+        echo ">>>> XBuild initializing project ... <<<<"
+        if [ -f "./CMakeLists.txt" ]; then
+            echo "[Error] MakeLists.txt already exists"
+            exit 1
+        fi
+        # Copy project templates
+        cp "$XBUILDROOT/cmake/templates/Template-Project-CMakeLists.txt" ./CMakeLists.txt
+        if [ ! -f "./CMakeLists.txt" ]; then
+            echo "[Error] Fail to copy MakeLists.txt"
+            exit 1
+        fi
+        # Make sub dirs: apps, libs, tests
+        if [ ! -d apps ]; then
+            mkdir -p apps
+        fi
+        if [ ! -d libs ]; then
+            mkdir -p libs
+        fi
+        if [ ! -d tests ]; then
+            mkdir -p tests
+        fi
+        echo "Project initialized."
+        exit 0
+    fi
+
     echo ">>>> XBuild creating target ... <<<<"
     if [ "$ARG_TARGET" == "" ]; then
         echo "[Error] Target is not defined (use \"--target <TARGETNAME>\" to define target)"
@@ -222,31 +252,102 @@ if [ "$XBUILD_COMMAND" == "create" ]; then
         echo "[Error] Target type is not defined (use \"--target-type <console|app|slib|dlib|test>\" to define target)"
         exit 1
     fi
-    if [ -d "./$ARG_TARGET" ]; then
-        echo "[Error] Target \"$ARG_TARGET\" already exist"
-        exit 1
-    fi
     if [ "$ARG_TARGET_TYPE" == "" ]; then
         echo "[Error] Target type is not defined (use \"--target-type <console|app|slib|dlib|test>\" to define target)"
         exit 1
     elif [ "$ARG_TARGET_TYPE" == "console" ]; then
         echo "Creating console application target: apps/$ARG_TARGET"
+        if [ -d "apps/$ARG_TARGET" ]; then
+            echo "[Error] Target \"apps/$ARG_TARGET\" already exists)"
+            exit 1
+        fi
+        mkdir -p apps/$ARG_TARGET/src
+        mkdir -p apps/$ARG_TARGET/include/$ARG_TARGET
+        cp "$XBUILDROOT/cmake/templates/Template-Target-Console-CMakeLists.txt" "apps/$ARG_TARGET/CMakeLists.txt"
+        cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "apps/$ARG_TARGET/Sources.cmake"
+        touch apps/$ARG_TARGET/src/$ARG_TARGET.cpp
+        touch apps/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+        echo "Target $ARG_TARGET created."
     elif [ "$ARG_TARGET_TYPE" == "app" ]; then
         echo "Creating gui application: apps/$ARG_TARGET"
+        if [ -d "apps/$ARG_TARGET" ]; then
+            echo "[Error] Target \"apps/$ARG_TARGET\" already exists)"
+            exit 1
+        fi
+        mkdir -p apps/$ARG_TARGET/src
+        mkdir -p apps/$ARG_TARGET/include/$ARG_TARGET
+        cp "$XBUILDROOT/cmake/templates/Template-Target-Win32-App-CMakeLists.txt" "apps/$ARG_TARGET/CMakeLists.txt"
+        cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "apps/$ARG_TARGET/Sources.cmake"
+        touch apps/$ARG_TARGET/src/$ARG_TARGET.cpp
+        touch apps/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+        echo "Target $ARG_TARGET created."
     elif [ "$ARG_TARGET_TYPE" == "slib" ]; then
         if [ "$ARG_TARGETMODE" == "kernel" ]; then
             echo "Creating kernel mode static library: libs/$ARG_TARGET"
+            if [ -d "apps/$ARG_TARGET" ]; then
+                echo "[Error] Target \"libs/$ARG_TARGET\" already exists)"
+                exit 1
+            fi
+            mkdir -p libs/$ARG_TARGET/src
+            mkdir -p libs/$ARG_TARGET/include/$ARG_TARGET
+            cp "$XBUILDROOT/cmake/templates/Template-Target-KernelLib-CMakeLists.txt" "libs/$ARG_TARGET/CMakeLists.txt"
+            cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "libs/$ARG_TARGET/Sources.cmake"
+            touch libs/$ARG_TARGET/src/$ARG_TARGET.c
+            touch libs/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+            echo "Target $ARG_TARGET created."
         else
             echo "Creating user mode static library: libs/$ARG_TARGET"
+            if [ -d "libs/$ARG_TARGET" ]; then
+                echo "[Error] Target \"libs/$ARG_TARGET\" already exists)"
+                exit 1
+            fi
+            mkdir -p libs/$ARG_TARGET/src
+            mkdir -p libs/$ARG_TARGET/include/$ARG_TARGET
+            cp "$XBUILDROOT/cmake/templates/Template-Target-StaticLib-CMakeLists.txt" "libs/$ARG_TARGET/CMakeLists.txt"
+            cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "libs/$ARG_TARGET/Sources.cmake"
+            touch libs/$ARG_TARGET/src/$ARG_TARGET.cpp
+            touch libs/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+            echo "Target $ARG_TARGET created."
         fi
     elif [ "$ARG_TARGET_TYPE" == "dlib" ]; then
         if [ "$ARG_TARGETMODE" == "kernel" ]; then
-            echo "Creating kernel mode driver: libs/$ARG_TARGET"
+            echo "Creating kernel mode driver: drivers/$ARG_TARGET"
+            if [ -d "drivers/$ARG_TARGET" ]; then
+                echo "[Error] Target \"drivers/$ARG_TARGET\" already exists)"
+                exit 1
+            fi
+            mkdir -p drivers/$ARG_TARGET/src
+            mkdir -p drivers/$ARG_TARGET/include/$ARG_TARGET
+            cp "$XBUILDROOT/cmake/templates/Template-Target-WinDrv-CMakeLists.txt" "drivers/$ARG_TARGET/CMakeLists.txt"
+            cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "drivers/$ARG_TARGET/Sources.cmake"
+            touch drivers/$ARG_TARGET/src/$ARG_TARGET.c
+            touch drivers/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+            echo "Target $ARG_TARGET created."
         else
             echo "Creating user mode dynamic-load library: libs/$ARG_TARGET"
+            if [ -d "libs/$ARG_TARGET" ]; then
+                echo "[Error] Target \"libs/$ARG_TARGET\" already exists)"
+                exit 1
+            fi
+            mkdir -p libs/$ARG_TARGET/src
+            mkdir -p libs/$ARG_TARGET/include/$ARG_TARGET
+            cp "$XBUILDROOT/cmake/templates/Template-Target-DynamicLib-CMakeLists.txt" "libs/$ARG_TARGET/CMakeLists.txt"
+            cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "libs/$ARG_TARGET/Sources.cmake"
+            touch libs/$ARG_TARGET/src/$ARG_TARGET.cpp
+            touch libs/$ARG_TARGET/include/$ARG_TARGET/$ARG_TARGET.h
+            echo "Target $ARG_TARGET created."
         fi
     elif [ "$ARG_TARGET_TYPE" == "test" ]; then
         echo "Creating test application: tests/$ARG_TARGET"
+        if [ -d "tests/$ARG_TARGET" ]; then
+            echo "[Error] Target \"tests/$ARG_TARGET\" already exists)"
+            exit 1
+        fi
+        mkdir -p tests/$ARG_TARGET/src
+        cp "$XBUILDROOT/cmake/templates/Template-Target-TestApp-CMakeLists.txt" "tests/$ARG_TARGET/CMakeLists.txt"
+        cp "$XBUILDROOT/cmake/templates/Template-Sources.cmake" "tests/$ARG_TARGET/Sources.cmake"
+        touch tests/$ARG_TARGET/src/$ARG_TARGET.cpp
+        echo "Target $ARG_TARGET created."
     fi
     exit 0
 fi
@@ -483,12 +584,12 @@ else
     echo "-- Fresh Build: no"
 fi
 # Is verbose enabled
-if [ "$ARG_FRESH" == "yes" ]; then
-    echo "-- Verbose: yes"
-    XBUILD_CONFIG_CMD="${XBUILD_CONFIG_CMD} --verbose"
-else
-    echo "-- Verbose: no"
-fi
+#f [ "$ARG_FRESH" == "yes" ]; then
+#   echo "-- Verbose: yes"
+#   XBUILD_CONFIG_CMD="${XBUILD_CONFIG_CMD} --verbose"
+#lse
+#   echo "-- Verbose: no"
+#i
 # - Definitions
 echo "-- Definitions:"
 for opt in "${ARG_OPTIONS[@]}"; do

--- a/cmake/templates/Template-Project-CMakeLists.txt
+++ b/cmake/templates/Template-Project-CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.26.5)
+include(FetchContent)
+
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+
+    if ("$ENV{XBUILDROOT}" STREQUAL "")
+        # Fetch xbuild-cmake prelude
+        message(STATUS "Fetching xbuild from github ...")
+        FetchContent_Declare(
+            xbuild
+            GIT_REPOSITORY https://github.com/realxye/xbuild.git
+            GIT_TAG        0c0f45fa7891c6625f96a86ab46f405854e251cb
+        )
+        FetchContent_MakeAvailable(xbuild)
+    else()
+        # Use local xbuild-cmake prelude
+        message(STATUS "Use local xbuild: $ENV{XBUILDROOT}/cmake")
+        include("$ENV{XBUILDROOT}/cmake/xbuild-prelude.cmake")
+    endif()
+
+    # Create project
+    xbd_project(<PROJECTNAME> C CXX)
+
+    # Get 3rd-party repos
+    # - catch2
+    FetchContent_Declare(
+        catch2
+        GIT_REPOSITORY git@github.com:catchorg/Catch2.git
+        GIT_TAG        v3.8.0
+    )
+    FetchContent_MakeAvailable(catch2)
+    set_target_properties(Catch2 PROPERTIES FOLDER ThirdParty)
+    set_target_properties(Catch2WithMain PROPERTIES FOLDER ThirdParty)
+
+endif()
+
+add_subdirectory(apps)
+add_subdirectory(libs)
+add_subdirectory(tests)

--- a/cmake/templates/Template-Sources.cmake
+++ b/cmake/templates/Template-Sources.cmake
@@ -1,0 +1,12 @@
+
+xbd_target_sources(${TARGETNAME}
+    SUBDIR include
+    SOURCES
+    ${TARGETNAME}/${TARGETNAME}.h
+)
+
+xbd_target_sources(${TARGETNAME}
+    SUBDIR src
+    SOURCES
+    ${TARGETNAME}.cpp
+)

--- a/cmake/templates/Template-Target-Console-CMakeLists.txt
+++ b/cmake/templates/Template-Target-Console-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_executable(${TARGETNAME} SUBSYSTEM "CONSOLE")
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER apps)

--- a/cmake/templates/Template-Target-DynamicLib-CMakeLists.txt
+++ b/cmake/templates/Template-Target-DynamicLib-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_library(${TARGETNAME} SHARED)
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER libs)

--- a/cmake/templates/Template-Target-KernelLib-CMakeLists.txt
+++ b/cmake/templates/Template-Target-KernelLib-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_kernel_library(${TARGETNAME})
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER libs)

--- a/cmake/templates/Template-Target-StaticLib-CMakeLists.txt
+++ b/cmake/templates/Template-Target-StaticLib-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_library(${TARGETNAME})
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER libs)

--- a/cmake/templates/Template-Target-TestApp-CMakeLists.txt
+++ b/cmake/templates/Template-Target-TestApp-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_executable(${TARGETNAME} SUBSYSTEM "CONSOLE")
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER tests)

--- a/cmake/templates/Template-Target-Win32-App-CMakeLists.txt
+++ b/cmake/templates/Template-Target-Win32-App-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_executable(${TARGETNAME} SUBSYSTEM "WINDOWS")
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER apps)

--- a/cmake/templates/Template-Target-WinDrv-CMakeLists.txt
+++ b/cmake/templates/Template-Target-WinDrv-CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(TARGETNAME <YOUR-TARGET-NAME>)
+xbd_add_kernel_driver(${TARGETNAME})
+
+set_target_properties (${TARGETNAME} PROPERTIES FOLDER drivers)


### PR DESCRIPTION
Support `git xbuild create` command:

- `git xbuild create --project`: initialize project in current directory
- `git xbuild create --target TARGETNAME --target-type console`: create a console target
- `git xbuild create --target TARGETNAME --target-type app`: create a Win32 app target
- `git xbuild create --target TARGETNAME --target-type slib`: create a static library target
- `git xbuild create --target TARGETNAME --target-type slib --kernel`: create a kernel mode static library target
- `git xbuild create --target TARGETNAME --target-type dlib`: create a user mode dynamic library target
- `git xbuild create --target TARGETNAME --target-type dlib --kernel`: create a kernel mode driver target
- `git xbuild create --target TARGETNAME --target-type test`: create a test app target